### PR TITLE
Split demo app into one tab per chart type

### DIFF
--- a/ChartViewV2Demo/ContentView.swift
+++ b/ChartViewV2Demo/ContentView.swift
@@ -10,50 +10,105 @@ import SwiftUI
 import SwiftUICharts
 
 struct ContentView: View {
-    @State var data1: [Double] = (0..<16).map { _ in .random(in: 9.0...100.0) }
-    @State var data2: [Double] = (0..<16).map { _ in .random(in: 9.0...100.0) }
-    @State var data3: [Double] = (0..<12).map { _ in .random(in: 9.0...100.0) }
 
-    let mixedColorStyle = ChartStyle(backgroundColor: .white, foregroundColor: [
-        ColorGradient(ChartColors.orangeBright, ChartColors.orangeDark),
-        ColorGradient(.purple, .blue)
-    ])
-    let blueStlye = ChartStyle(backgroundColor: .white,
-                               foregroundColor: [ColorGradient(.purple, .blue)])
-    let orangeStlye = ChartStyle(backgroundColor: .white,
-                                 foregroundColor: [ColorGradient(ChartColors.orangeBright, ChartColors.orangeDark)])
+	@State private var selectedTab = 1
 
-    var body: some View {
-        VStack(alignment: .center, spacing: 12.0) {
-            BarChart()
-                .data(data2)
-                .chartStyle(mixedColorStyle)
+	@State var data1: [Double] = (0..<16).map { _ in .random(in: 9.0...100.0) }
+	@State var data2: [Double] = (0..<16).map { _ in .random(in: 9.0...100.0) }
+	@State var data3: [Double] = (0..<12).map { _ in .random(in: 9.0...100.0) }
 
-            CardView(showShadow: false) {
-                ChartLabel("Title", type: .subTitle)
-                LineChart()
-            }
-            .data(data1)
-            .chartStyle(blueStlye)
+	let mixedColorStyle = ChartStyle(backgroundColor: .white, foregroundColor: [
+		ColorGradient(ChartColors.orangeBright, ChartColors.orangeDark),
+		ColorGradient(.purple, .blue)
+	])
+	let blueStlye = ChartStyle(backgroundColor: .white,
+							   foregroundColor: [ColorGradient(.purple, .blue)])
+	let orangeStlye = ChartStyle(backgroundColor: .white,
+								 foregroundColor: [ColorGradient(ChartColors.orangeBright, ChartColors.orangeDark)])
 
-            CardView {
-                ChartLabel("Title", type: .title)
-                BarChart()
-            }
-            .data(data3)
-            .chartStyle(orangeStlye)
-            .frame(width: 160, height: 240)
-            .padding()
+	var body: some View {
+		VStack {
 
-            Button(action: {
-                self.data1 = (0..<16).map { _ in .random(in: 9.0...100.0) } as [Double]
-                self.data2 = (0..<16).map { _ in .random(in: 9.0...100.0) } as [Double]
-                self.data3 = (0..<16).map { _ in .random(in: 9.0...100.0) } as [Double]
-            }) {
-                Text("Shuffle baby")
-            }
-        }
-    }
+			HStack {
+				Button(action: {
+					self.data1 = (0..<16).map { _ in .random(in: 9.0...100.0) } as [Double]
+					self.data2 = (0..<16).map { _ in .random(in: 9.0...100.0) } as [Double]
+					self.data3 = (0..<16).map { _ in .random(in: 9.0...100.0) } as [Double]
+				}) {
+					Text("Shuffle baby")
+				}
+
+				Spacer()
+				// Other controls
+			}
+			.padding()
+
+			TabView(selection: $selectedTab) {
+
+				VStack {
+
+					BarChart()
+						.data(data2)
+						.chartStyle(mixedColorStyle)
+
+
+					CardView {
+						ChartLabel("Bar Chart", type: .legend)
+						BarChart()
+					}
+					.data(data3)
+					.chartStyle(orangeStlye)
+					.frame(width: 160, height: 240)
+					.padding()
+				}
+				.tabItem { Image(systemName:"chart.bar.xaxis") }.tag(1)
+				VStack {
+
+					PieChart()
+						.data(data1)
+						.chartStyle(orangeStlye)
+
+					CardView {
+						ChartLabel("Pie Chart", type: .title)
+						PieChart()
+					}
+					.data(data2)
+					.chartStyle(blueStlye)
+					.padding()
+
+
+				}
+				.tabItem { Image(systemName:"chart.pie.fill") }.tag(2)
+
+
+
+				VStack {
+
+					CardView(showShadow: true) {
+						ChartLabel("Line Chart", type: .subTitle)
+						LineChart()
+					}
+					.data(data1)
+					.chartStyle(blueStlye)
+					.padding()
+
+
+					LineChart()
+						.data(data2)
+						.chartStyle(orangeStlye)
+
+				}
+				.tabItem { Image(systemName:"waveform.path.ecg.rectangle") }.tag(3)
+
+				VStack {
+
+					// More types to come
+
+				}
+				.tabItem { Image(systemName:"questionmark.diamond.fill") }.tag(4)
+			}
+		}
+	}
 }
 
 struct ContentView_Previews: PreviewProvider {
@@ -61,3 +116,4 @@ struct ContentView_Previews: PreviewProvider {
         ContentView()
     }
 }
+

--- a/ChartViewV2Demo/ContentView.swift
+++ b/ChartViewV2Demo/ContentView.swift
@@ -21,9 +21,9 @@ struct ContentView: View {
 		ColorGradient(ChartColors.orangeBright, ChartColors.orangeDark),
 		ColorGradient(.purple, .blue)
 	])
-	let blueStlye = ChartStyle(backgroundColor: .white,
+	let blueStyle = ChartStyle(backgroundColor: .white,
 							   foregroundColor: [ColorGradient(.purple, .blue)])
-	let orangeStlye = ChartStyle(backgroundColor: .white,
+	let orangeStyle = ChartStyle(backgroundColor: .white,
 								 foregroundColor: [ColorGradient(ChartColors.orangeBright, ChartColors.orangeDark)])
 
 	var body: some View {
@@ -57,7 +57,7 @@ struct ContentView: View {
 						BarChart()
 					}
 					.data(data3)
-					.chartStyle(orangeStlye)
+					.chartStyle(orangeStyle)
 					.frame(width: 160, height: 240)
 					.padding()
 				}
@@ -66,14 +66,14 @@ struct ContentView: View {
 
 					PieChart()
 						.data(data1)
-						.chartStyle(orangeStlye)
+						.chartStyle(orangeStyle)
 
 					CardView {
 						ChartLabel("Pie Chart", type: .title)
 						PieChart()
 					}
 					.data(data2)
-					.chartStyle(blueStlye)
+					.chartStyle(blueStyle)
 					.padding()
 
 
@@ -89,13 +89,13 @@ struct ContentView: View {
 						LineChart()
 					}
 					.data(data1)
-					.chartStyle(blueStlye)
+					.chartStyle(blueStyle)
 					.padding()
 
 
 					LineChart()
 						.data(data2)
-						.chartStyle(orangeStlye)
+						.chartStyle(orangeStyle)
 
 				}
 				.tabItem { Image(systemName:"waveform.path.ecg.rectangle") }.tag(3)


### PR DESCRIPTION
It's hard to show off all the chart types on a single display, so this makes a tab view that allows us to see more than one example of each chart type in a separate tab.

Note: This exhibits a bug where the first display of the line graph is sized strangely, and animates strangely. I think that this is a bug in the line graph code, not the demo app, so I'm not addressing it here.